### PR TITLE
1. 增加对MacOS和BSD类系统的支持 2.增加对zsh不兼容的声明 3.更改该脚本许可证为MIT LICENSE

### DIFF
--- a/UVa/LICENSE
+++ b/UVa/LICENSE
@@ -1,47 +1,3 @@
-# Download script for UVa Online Judge
-[![][license img]][license]
-
-UVa Online Judge 题目下载，批量拉取 PDF 题目。
-
-## Function
-
- - [x] Multi-Thread using FIFO (多线程)
- - [x] Errorlog (错误日志)
- - [x] Timing (下载计时)
- - [x] MultiPlatform
-
-## Platform
-
- - [x] WSL
- - [x] MinGW
- - [x] GNU/Linux
- - [x] MacOS
- - [x] BSDs
-
-## Run
-
-This script is incompatible with zsh.
-
-To run the script with a default number of 20 threads, do the following:
-
-```
-$ bash download.sh
-```
-To run the script with a customized number of threads, do the following:
-
-```
-$ bash download.sh "threads" (without quotes)
-```
-e.g.
-```
-$ bash download.sh 20
-```
-
-## License
-
-Download script for UVa Online Judge is available under the [MIT license](http://opensource.org/licenses/MIT).
-
-```
 MIT License
 
 Copyright (c) 2016-2017 METO, Chijun Sima
@@ -63,7 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-```
-
-[license]:LICENSE
-[license img]:https://img.shields.io/github/license/mashape/apistatus.svg?style=flat-square

--- a/UVa/README.md
+++ b/UVa/README.md
@@ -7,6 +7,15 @@ UVa Online Judge 题目下载，批量拉取 PDF 题目。
  - [x] Multi-Thread using FIFO (多线程)
  - [x] Errorlog (错误日志)
  - [x] Timing (下载计时)
+ - [x] MultiPlatform
+
+## Platform
+
+ - [x] WSL
+ - [x] MinGW
+ - [x] GNU/Linux
+ - [x] MacOS
+ - [x] BSDs
 
 ## Run
 

--- a/UVa/README.md
+++ b/UVa/README.md
@@ -19,6 +19,8 @@ UVa Online Judge 题目下载，批量拉取 PDF 题目。
 
 ## Run
 
+This script is incompatible with zsh.
+
 To run the script with a default number of 20 threads, do the following:
 
 ```

--- a/UVa/download.sh
+++ b/UVa/download.sh
@@ -32,7 +32,7 @@ do
 		{
 			beginat=$(date +%s)
 			echo -e "\e[5;32m[Starting]\e[0m to download \e[4;34m $id \e[0m in UVa Volume \e[4;34m $volume \e[0m..."
-			if wget --tries=2 --timeout=45 -q https://uva.onlinejudge.org/external/$volume/$id.pdf
+			if curl --retry 2 --connect-timeout 45 --silent -O https://uva.onlinejudge.org/external/$volume/$id.pdf
 			then
 			{
 				endat=$(date +%s)


### PR DESCRIPTION
**1. 增加对MacOS和BSD类系统的支持** 
起因：有人希望我把默认不带wget的MacOS的系统支持加上
解决方案：把wget改成curl
现状：支持了MacOS和BSD（未经测试）

**2.增加对zsh不兼容的声明**
经测试，zsh对命名管道的处理明显跟bash不同
收到SIGINT（Ctrl-C）反应与bash不同
（没有计划改进）

**3.更改该脚本许可证为MIT LICENSE**
起因：无许可证状态法律上不允许更改、分发……
解决：**只给这一个script**加了LICENSE
解决后：解决了以上问题，而且更换许可证方便（可以换成更强的许可证）